### PR TITLE
Rename name of nodejs endpoint for better Che/CRW compatibility

### DIFF
--- a/devfiles/nodejs/devfile.yaml
+++ b/devfiles/nodejs/devfile.yaml
@@ -14,7 +14,7 @@ components:
     memoryLimit: 1024Mi
     mountSources: true
     endpoints:
-      - name: "3000/tcp"
+      - name: "nodejs"
         port: 3000
 commands:
   - name: devBuild


### PR DESCRIPTION
Allows the devfile's endpoint to be better exposed when running in Che/CRW