### PR TITLE
[WIP][v1] Transfer logic of devfile support check from odo

### DIFF
--- a/devfiles/index.json
+++ b/devfiles/index.json
@@ -1,5 +1,6 @@
 [
   {
+    "name": "maven",
     "displayName": "Maven Java",
     "description": "Upstream Maven and OpenJDK 11",
     "tags": [
@@ -8,11 +9,13 @@
     ],
     "projectType": "maven",
     "language": "java",
+    "supported": true,
     "links": {
       "self": "/devfiles/maven/devfile.yaml"
     }
   },
   {
+    "name": "nodejs",
     "displayName": "NodeJS Express Web Application",
     "description": "Stack with NodeJS 10",
     "tags": [
@@ -22,20 +25,39 @@
     ],
     "projectType": "nodejs",
     "language": "nodejs",
+    "supported": true,
     "links": {
       "self": "/devfiles/nodejs/devfile.yaml"
     }
   },
   {
+    "name": "openLiberty",
     "displayName": "Open Liberty",
     "description": "Open Liberty microservice in Java",
     "projectType": "docker",
     "language": "java",
+    "supported": true,
     "links": {
       "self": "/devfiles/openLiberty/devfile.yaml"
     }
   },
   {
+    "name": "quarkus",
+    "displayName": "Quarkus Java",
+    "description": "Upstream Quarkus with Java+GraalVM",
+    "tags": [
+      "Java",
+      "Quarkus"
+    ],
+    "projectType": "quarkus",
+    "language": "java",
+    "supported": true,
+    "links": {
+      "self": "/devfiles/quarkus/devfile.yaml"
+    }
+  },
+  {
+    "name": "springBoot",
     "displayName": "Spring Boot®",
     "description": "Spring Boot® using Java",
     "tags": [
@@ -46,21 +68,9 @@
     "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
     "projectType": "spring",
     "language": "java",
+    "supported": true,
     "links": {
       "self": "/devfiles/springBoot/devfile.yaml"
-    }
-  },
-  {
-    "displayName": "Quarkus Java",
-    "description": "Upstream Quarkus with Java+GraalVM",
-    "tags": [
-      "Java",
-      "Quarkus"
-    ],
-    "projectType": "quarkus",
-    "language": "java",
-    "links": {
-      "self": "/devfiles/quarkus/devfile.yaml"
     }
   }
 ]

--- a/devfiles/maven/meta.yaml
+++ b/devfiles/maven/meta.yaml
@@ -1,3 +1,4 @@
+name: maven
 displayName: Maven Java
 description: Upstream Maven and OpenJDK 11
 tags: ["Java", "Maven"]

--- a/devfiles/nodejs/meta.yaml
+++ b/devfiles/nodejs/meta.yaml
@@ -1,3 +1,4 @@
+name: nodejs
 displayName: NodeJS Express Web Application
 description: Stack with NodeJS 10
 tags: ["NodeJS", "Express", "ubi8"]

--- a/devfiles/openLiberty/meta.yaml
+++ b/devfiles/openLiberty/meta.yaml
@@ -1,3 +1,4 @@
+name: openLiberty
 displayName: "Open Liberty"
 description: "Open Liberty microservice in Java"
 language: "java"

--- a/devfiles/quarkus/meta.yaml
+++ b/devfiles/quarkus/meta.yaml
@@ -1,3 +1,4 @@
+name: quarkus
 displayName: Quarkus Java
 description: Upstream Quarkus with Java+GraalVM
 tags: ["Java", "Quarkus"]

--- a/devfiles/springBoot/meta.yaml
+++ b/devfiles/springBoot/meta.yaml
@@ -1,3 +1,4 @@
+name: springBoot
 displayName: Spring Boot®
 description: Spring Boot® using Java
 tags: ["Java", "Spring"]

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,4 @@ module github.com/elsony/devfile-registry/tools
 
 go 1.14
 
-require (
-	github.com/ghodss/yaml v1.0.0
-	gopkg.in/yaml.v2 v2.2.8 // indirect
-)
+require gopkg.in/yaml.v2 v2.2.8

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,4 +2,7 @@ module github.com/elsony/devfile-registry/tools
 
 go 1.14
 
-require gopkg.in/yaml.v2 v2.2.8 // indirect
+require (
+	github.com/ghodss/yaml v1.0.0
+	gopkg.in/yaml.v2 v2.2.8 // indirect
+)

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,5 +1,3 @@
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
-github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,3 +1,5 @@
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tools/types/devfile.go
+++ b/tools/types/devfile.go
@@ -1,0 +1,25 @@
+package types
+
+// Devfile is the main structure of devfile from devfile registry
+type Devfile struct {
+	APIVersion string      `yaml:"apiVersion"`
+	MetaData   Metadata    `yaml:"metadata"`
+	Components []Component `yaml:"components"`
+	Commands   []Command   `yaml:"commands"`
+}
+
+// Metadata holds the meta information in the devfile
+type Metadata struct {
+	GenerateName string `yaml:"generateName"`
+}
+
+// Component holds the partial component information in the devfile
+type Component struct {
+	Type  string `yaml:"type"`
+	Alias string `yaml:"alias"`
+}
+
+// Command holds the partial command information in the devfile
+type Command struct {
+	Name string `yaml:"name"`
+}

--- a/tools/types/meta.go
+++ b/tools/types/meta.go
@@ -2,6 +2,7 @@ package types
 
 // Meta represents meta.yaml file
 type Meta struct {
+	Name              string   `yaml:"name,omitempty" json:"name,omitempty"`
 	DisplayName       string   `yaml:"displayName,omitempty" json:"displayName,omitempty"`
 	Description       string   `yaml:"description,omitempty" json:"description,omitempty"`
 	Tags              []string `yaml:"tags,omitempty" json:"tags,omitempty"`
@@ -15,7 +16,8 @@ type Meta struct {
 // This is Meta extended with Links field
 type MetaIndex struct {
 	Meta
-	Links Links `yaml:"links,omitempty" json:"links,omitempty"`
+	Supported bool  `yaml:"supported" json:"supported"`
+	Links     Links `yaml:"links,omitempty" json:"links,omitempty"`
 }
 type Links struct {
 	Self string `yaml:"self,omitempty" json:"self,omitempty"`

--- a/tools/utils/utils.go
+++ b/tools/utils/utils.go
@@ -13,11 +13,9 @@ const (
 	dockerImageComponent = "dockerimage"
 )
 
-// IsDevfileSupported checks if devfile v1 is supported
-func IsDevfileSupported(devfile types.Devfile) bool {
-
+// isContainerPresent checks if the devfile has a supported container
+func isContainerPresent(devfile types.Devfile) bool {
 	hasSupportedContainer := false
-	hasRunCommand := false
 
 	for _, component := range devfile.Components {
 		if strings.Contains(component.Type, dockerImageComponent) && component.Alias != "" {
@@ -26,12 +24,28 @@ func IsDevfileSupported(devfile types.Devfile) bool {
 		}
 	}
 
+	return hasSupportedContainer
+}
+
+// isRunCommandPresent checks if the devfile has a devrun command
+func isRunCommandPresent(devfile types.Devfile) bool {
+	hasRunCommand := false
+
 	for _, command := range devfile.Commands {
 		if strings.Contains(strings.ToLower(command.Name), string(defaultRunCommand)) {
 			hasRunCommand = true
 			break
 		}
 	}
+
+	return hasRunCommand
+}
+
+// IsDevfileSupported checks if devfile v1 is supported
+func IsDevfileSupported(devfile types.Devfile) bool {
+
+	hasSupportedContainer := isContainerPresent(devfile)
+	hasRunCommand := isRunCommandPresent(devfile)
 
 	return hasSupportedContainer && hasRunCommand
 }

--- a/tools/utils/utils.go
+++ b/tools/utils/utils.go
@@ -1,0 +1,82 @@
+package utils
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"github.com/elsony/devfile-registry/tools/types"
+	"github.com/ghodss/yaml"
+)
+
+const (
+	defaultRunCommand    = "devrun"
+	dockerImageComponent = "dockerimage"
+)
+
+// IsDevfileSupported checks if devfile v1 is supported
+func IsDevfileSupported(devfile types.Devfile) bool {
+
+	hasDockerImage := false
+	hasAlias := false
+	hasRunCommand := false
+
+	for _, component := range devfile.Components {
+		if hasDockerImage && hasAlias {
+			break
+		}
+
+		if !hasDockerImage {
+			hasDockerImage = strings.Contains(component.Type, dockerImageComponent)
+		}
+
+		if !hasAlias {
+			hasAlias = len(component.Alias) > 0
+		}
+	}
+
+	for _, command := range devfile.Commands {
+		if hasRunCommand {
+			break
+		}
+
+		if !hasRunCommand {
+			hasRunCommand = strings.Contains(strings.ToLower(command.Name), string(defaultRunCommand))
+		}
+	}
+
+	if hasDockerImage && hasAlias && hasRunCommand {
+		return true
+	}
+
+	return false
+}
+
+// GetDevfile reads the devfile from the path and returns the devfile struct
+func GetDevfile(devfilePath string) (types.Devfile, error) {
+	var devfile types.Devfile
+	devFilePath, err := ioutil.ReadFile(devfilePath)
+	if err != nil {
+		return types.Devfile{}, err
+	}
+	err = yaml.Unmarshal(devFilePath, &devfile)
+	if err != nil {
+		return types.Devfile{}, err
+	}
+
+	return devfile, nil
+}
+
+// GetMeta reads the meta.yaml and returns the meta struct
+func GetMeta(metafilePath string) (types.Meta, error) {
+	var meta types.Meta
+	metaFilePath, err := ioutil.ReadFile(metafilePath)
+	if err != nil {
+		return types.Meta{}, err
+	}
+	err = yaml.Unmarshal(metaFilePath, &meta)
+	if err != nil {
+		return types.Meta{}, err
+	}
+
+	return meta, nil
+}

--- a/tools/utils/utils.go
+++ b/tools/utils/utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/elsony/devfile-registry/tools/types"
-	"github.com/ghodss/yaml"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -16,39 +16,24 @@ const (
 // IsDevfileSupported checks if devfile v1 is supported
 func IsDevfileSupported(devfile types.Devfile) bool {
 
-	hasDockerImage := false
-	hasAlias := false
+	hasSupportedContainer := false
 	hasRunCommand := false
 
 	for _, component := range devfile.Components {
-		if hasDockerImage && hasAlias {
+		if strings.Contains(component.Type, dockerImageComponent) && component.Alias != "" {
+			hasSupportedContainer = true
 			break
-		}
-
-		if !hasDockerImage {
-			hasDockerImage = strings.Contains(component.Type, dockerImageComponent)
-		}
-
-		if !hasAlias {
-			hasAlias = len(component.Alias) > 0
 		}
 	}
 
 	for _, command := range devfile.Commands {
-		if hasRunCommand {
+		if strings.Contains(strings.ToLower(command.Name), string(defaultRunCommand)) {
+			hasRunCommand = true
 			break
 		}
-
-		if !hasRunCommand {
-			hasRunCommand = strings.Contains(strings.ToLower(command.Name), string(defaultRunCommand))
-		}
 	}
 
-	if hasDockerImage && hasAlias && hasRunCommand {
-		return true
-	}
-
-	return false
+	return hasSupportedContainer && hasRunCommand
 }
 
 // GetDevfile reads the devfile from the path and returns the devfile struct


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysun.j.faisal@ibm.com>

For Issue https://github.com/openshift/odo/issues/3249
This PR moved the logic from odo to this repo to check if a devfile is supported.

This is done so that odo does not parse the devfile but rather read the index.json for information and this improves `odo catalog list components` performance with big registries

V2 PR at https://github.com/odo-devfiles/registry/pull/3

Confirmed that merging this wont break master branch v1 `odo catalog list components`:

This PR changes
```
Maysuns-MacBook-Pro:springboot-ex maysun$ odo catalog list components
Odo Devfile Components:
NAME                 DESCRIPTION                            REGISTRY                   SUPPORTED
nodejs               Stack with NodeJS 10                   DefaultDevfileRegistry     YES
java-spring-boot     Spring Boot® using Java                DefaultDevfileRegistry     YES
java-openliberty     Open Liberty microservice in Java      DefaultDevfileRegistry     YES
quarkus              Upstream Quarkus with Java+GraalVM     DefaultDevfileRegistry     YES
maven                Upstream Maven and OpenJDK 11          DefaultDevfileRegistry     YES

Maysuns-MacBook-Pro:springboot-ex maysun$ odo registry list
NAME                       URL
CheDevfileRegistry         https://che-devfile-registry.openshift.io
DefaultDevfileRegistry     https://raw.githubusercontent.com/maysunfaisal/devfile-registry/update-registry-index-support-1
```

comparison to master changes:
```
Maysuns-MacBook-Pro:springboot-ex maysun$ odo catalog list components
Odo Devfile Components:
NAME                 DESCRIPTION                            REGISTRY                   SUPPORTED
quarkus              Upstream Quarkus with Java+GraalVM     DefaultDevfileRegistry     YES
nodejs               Stack with NodeJS 10                   DefaultDevfileRegistry     YES
java-spring-boot     Spring Boot® using Java                DefaultDevfileRegistry     YES
maven                Upstream Maven and OpenJDK 11          DefaultDevfileRegistry     YES
java-openliberty     Open Liberty microservice in Java      DefaultDevfileRegistry     YES


Maysuns-MacBook-Pro:springboot-ex maysun$ odo registry list
NAME                       URL
CheDevfileRegistry         https://che-devfile-registry.openshift.io
DefaultDevfileRegistry     https://raw.githubusercontent.com/elsony/devfile-registry/master
```