### PR TITLE
Ol inner loop refined

### DIFF
--- a/devfiles/openLiberty/.gitignore
+++ b/devfiles/openLiberty/.gitignore
@@ -1,2 +1,0 @@
-
-.odo/odo-file-index.json

--- a/devfiles/openLiberty/devfile.yaml
+++ b/devfiles/openLiberty/devfile.yaml
@@ -1,39 +1,38 @@
+apiVersion: 1.0.0
 metadata:
-  name: java-openliberty
+  name: openLiberty
+attributes:
+  odo.autorestart: "false"
 projects:
-  - name: user-app
+  - name: user-app 
     source:
-      location: 'https://github.com/OpenLiberty/application-stack.git'
       type: git
+      location: 'https://github.com/OpenLiberty/application-stack.git'
       sparseCheckoutDir: /templates/default
 components:
-  - id: redhat/java/latest
-    memoryLimit: 1512Mi
-    type: chePlugin
-  - mountSources: true
+- type: chePlugin
+  id: redhat/java/latest
+  memoryLimit: 1512Mi
+- alias: devruntime
+  mountSources: true
+  type: dockerimage
+  image: kabanero/ubi8-maven:0.3.1 
+  memoryLimit: 1512Mi
+  volumes:
+  - name: m2
+    containerPath: /home/user/.m2
     endpoints:
-      - name: 9080/tcp
-        port: 9080
-    memoryLimit: 1512Mi
-    type: dockerimage
-    alias: appsodyrun
-    image: 'kabanero/ubi8-maven:0.3.1'
-    env:
-      - value: TEST2
-        name: MODE2
-      - value: myval2
-        name: myprop2
-    volumes:
-      - name: m2
-        containerPath: /root/.m2/repository
-apiVersion: 1.0.0
+  - name: 9080/tcp
+    port: 9080
+  - name: 9443/tcp
+    port: 9443
 commands:
   - name: devInit
     actions:
       - workdir: /projects/user-app
         type: exec
         command: mvn -B liberty:install-server liberty:create liberty:install-feature dependency:go-offline
-        component: appsodyrun 
+        component: devruntime 
   - name: devBuild
     actions:
       - workdir: /projects/user-app
@@ -44,12 +43,12 @@ commands:
                  else
                      echo "will run the devBuild command" && mvn package && touch ./.disable-bld-cmd;
                  fi 
-        component: appsodyrun
+        component: devruntime 
   - name: devRun
     actions:
       - workdir: /projects/user-app
         type: exec
         command: mvn -DhotTests=true liberty:dev
-        component: appsodyrun
+        component: devruntime 
     attributes:
         restart: "false"

--- a/devfiles/openLiberty/devfile.yaml
+++ b/devfiles/openLiberty/devfile.yaml
@@ -1,6 +1,6 @@
 apiVersion: 1.0.0
 metadata:
-  name: openLiberty
+  generateName: java-openliberty 
 attributes:
   odo.autorestart: "false"
 projects:
@@ -21,7 +21,7 @@ components:
   volumes:
   - name: m2
     containerPath: /home/user/.m2
-    endpoints:
+  endpoints:
   - name: 9080/tcp
     port: 9080
   - name: 9443/tcp

--- a/devfiles/openLiberty/devfile.yaml
+++ b/devfiles/openLiberty/devfile.yaml
@@ -1,11 +1,11 @@
 metadata:
-  generateName: java-openliberty
+  name: java-openliberty
 projects:
   - name: user-app
     source:
-      location: 'https://github.com/odo-devfiles/openliberty-ex.git'
+      location: 'https://github.com/OpenLiberty/application-stack.git'
       type: git
-      branch: master
+      sparseCheckoutDir: /templates/default
 components:
   - id: redhat/java/latest
     memoryLimit: 1512Mi
@@ -17,19 +17,39 @@ components:
     memoryLimit: 1512Mi
     type: dockerimage
     alias: appsodyrun
-    image: 'ajymau/java-openliberty-dev:latest'
+    image: 'kabanero/ubi8-maven:0.3.1'
     env:
       - value: TEST2
         name: MODE2
       - value: myval2
         name: myprop2
+    volumes:
+      - name: m2
+        containerPath: /root/.m2/repository
 apiVersion: 1.0.0
 commands:
+  - name: devInit
+    actions:
+      - workdir: /projects/user-app
+        type: exec
+        command: mvn -B liberty:install-server liberty:create liberty:install-feature dependency:go-offline
+        component: appsodyrun 
+  - name: devBuild
+    actions:
+      - workdir: /projects/user-app
+        type: exec
+        command: if [ -e /projects/user-app/.disable-bld-cmd ]; 
+                 then 
+                     echo "found the disable file" && echo "devBuild command will not run" && exit 0; 
+                 else
+                     echo "will run the devBuild command" && mvn package && touch ./.disable-bld-cmd;
+                 fi 
+        component: appsodyrun
   - name: devRun
     actions:
       - workdir: /projects/user-app
         type: exec
-        command: mvn -DhotTests=true -DappsDirectory=apps -Dmaven.repo.local=/mvn/repository liberty:dev
+        command: mvn -DhotTests=true liberty:dev
         component: appsodyrun
     attributes:
         restart: "false"


### PR DESCRIPTION
templates will be introduced to the devfile over time as additional projects that will use the sparseCheckoutDir setting.

templates will be housed/released in our application-stack repo and pointed to by this devfile
(github.com/OpenLiberty/application-stack.git)

I have closed the window on the devRun command to be as tight as possible - all dependency processing, liberty install and config is now split between the devInit cmd and a smart devBuild command. the only thing th edevRun command will process on forst push is the start up of the server and app.