### PR TITLE
pin version of ol used by liberty:dev mode to that of custom image - …

### DIFF
--- a/devfiles/openLiberty/devfile.yaml
+++ b/devfiles/openLiberty/devfile.yaml
@@ -47,7 +47,7 @@ commands:
     actions:
       - workdir: /projects/user-app
         type: exec
-        command: mvn -DhotTests=true liberty:dev
+        command: mvn -Dliberty.runtime.version=20.0.0.6 -DhotTests=true liberty:dev
         component: devruntime
     attributes:
         restart: "false"


### PR DESCRIPTION
devfile liberty:dev commands should explicitly execute against the same level/version of ol that is installed in the custom base image - currently ol 20.0.0.6